### PR TITLE
adding vocabularies prefix filters for omeka modules

### DIFF
--- a/omekasToRDF.py
+++ b/omekasToRDF.py
@@ -13,6 +13,8 @@ from triplesCreation import *
 from constants import *
 
 
+#TODO check trailing / in API_PATH
+
 def alterFilesPermissions():
 
     # RDF files


### PR DESCRIPTION
J'ai eu quelques erreurs sur les prefix (dans les log) qui empechait le script de fonctionner. 
Les erreurs concernaient les prefix de module omeka (genre "o-module-mapping:marker"). 
J'ai juste complété le filtre et rajouté un cas où le prefix n'était pas connu (autre prefix interne de omeka dans une future version par exemple)